### PR TITLE
refactor: remove nitro checks

### DIFF
--- a/src/utils/resolve.ts
+++ b/src/utils/resolve.ts
@@ -32,8 +32,7 @@ function resolveEmojis(str: string, client: Client<true>): string {
 
 		const predicate = ({ name, animated }: GuildEmoji) => (hasPremium || !animated) && name === g1;
 
-		const emoji =
-			client.currentGuild.emojis.cache.find(predicate) ?? hasPremium ? client.emojis.cache.find(predicate) : null;
+		const emoji = client.currentGuild.emojis.cache.find(predicate) ?? client.emojis.cache.find(predicate);
 
 		return emoji?.toString() ?? match;
 	});


### PR DESCRIPTION
This pr removes nitro checks as discord converts emotes into raw strings either way without their IDs